### PR TITLE
Fixed incorrect markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,5 +78,5 @@ Most discussions happen on our [Discord Server](https://discord.gg/s4BskkKf), wh
 
 This software is licensed under the terms of the GPLv2, with exemptions noted below:
 
-[Nintendo] (https://github.com/Nintendo) is exempt from GPLv2 licensing and may (at its option) instead license any source code authored for this project under the MIT license.
+[Nintendo](https://github.com/Nintendo) is exempt from GPLv2 licensing and may (at its option) instead license any source code authored for this project under the MIT license.
 


### PR DESCRIPTION
Adding a space after the brackets prevents the hyperlink from working - this pull request fixes that.