### PR TITLE
Fixed "min" and "max" identifier not found errors

### DIFF
--- a/src/port/controller/keyboard.cpp
+++ b/src/port/controller/keyboard.cpp
@@ -8,6 +8,7 @@
 #endif
 #include <fstream>
 #include <unordered_map>
+#include <algorithm>
 
 #if !defined(DISABLE_SDL_CONTROLLER)
 #include <SDL2/SDL.h>

--- a/src/port/player/players.cpp
+++ b/src/port/player/players.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include "players.h"
 #include "../controller/controllers.h"
 


### PR DESCRIPTION
When I tried to compile, I was met with these errors:
"min" identifier not found (keyboard.cpp)
"max" identifier not found (players.cpp)

All I did to fix them was include <algorithm> in the headers.