### PR TITLE
Added compiler flag to increase render distance

### DIFF
--- a/include/def/z_actor.h
+++ b/include/def/z_actor.h
@@ -146,7 +146,7 @@ void func_8002F994(Actor* actor, s32 arg1);
 s32 func_8002F9EC(GlobalContext* globalCtx, Actor* actor, CollisionPoly* poly, s32 bgId, Vec3f* pos);
 void func_800304B0(GlobalContext* globalCtx);
 void func_800304DC(GlobalContext* globalCtx, ActorContext* actorCtx, ActorEntry* actorEntry);
-s32 func_800314D4(GlobalContext* globalCtx, Actor* actorB, Vec3f* arg2, f32 arg3);
+s32 Actor_IsInUncullZone(GlobalContext* globalCtx, Actor* actorB, Vec3f* projectedPos, f32 projectedW);
 void func_800315AC(GlobalContext* globalCtx, ActorContext* actorCtx);
 void func_80031A28(GlobalContext* globalCtx, ActorContext* actorCtx);
 void func_80031B14(GlobalContext* globalCtx, ActorContext* actorCtx);

--- a/include/z64actor.h
+++ b/include/z64actor.h
@@ -114,7 +114,7 @@ typedef struct {
 #define ACTOR_FLAG_3 (1 << 3)
 #define ACTOR_FLAG_4 (1 << 4)
 #define ACTOR_FLAG_5 (1 << 5)
-#define ACTOR_FLAG_6 (1 << 6)
+#define ACTOR_FLAG_UNCULLED (1 << 6)
 #define ACTOR_FLAG_7 (1 << 7)
 #define ACTOR_FLAG_8 (1 << 8)
 #define ACTOR_FLAG_9 (1 << 9)
@@ -582,7 +582,7 @@ s32 func_8002F9EC(struct GlobalContext* globalCtx, Actor* actor, struct Collisio
 void func_800304B0(struct GlobalContext* globalCtx);
 void func_800304DC(struct GlobalContext* globalCtx, ActorContext* actorCtx, ActorEntry* actorEntry);
 void Actor_UpdateAll(struct GlobalContext* globalCtx, ActorContext* actorCtx);
-s32 func_800314D4(struct GlobalContext* globalCtx, Actor* actorB, Vec3f* arg2, f32 arg3);
+s32 Actor_IsInUncullZone(struct GlobalContext* globalCtx, Actor* actorB, Vec3f* arg2, f32 arg3);
 void func_800315AC(struct GlobalContext* globalCtx, ActorContext* actorCtx);
 void func_80031A28(struct GlobalContext* globalCtx, ActorContext* actorCtx);
 void func_80031B14(struct GlobalContext* globalCtx, ActorContext* actorCtx);

--- a/src/overlays/actors/ovl_Demo_Im/z_demo_im.c
+++ b/src/overlays/actors/ovl_Demo_Im/z_demo_im.c
@@ -846,7 +846,7 @@ s32 func_809869F8(DemoIm* this, GlobalContext* globalCtx) {
     f32 playerPosX = player->actor.world.pos.x;
     f32 thisPosX = this->actor.world.pos.x;
 
-    if ((thisPosX - (kREG(16) + 30.0f) > playerPosX) && !(this->actor.flags & ACTOR_FLAG_6)) {
+    if ((thisPosX - (kREG(16) + 30.0f) > playerPosX) && !(this->actor.flags & ACTOR_FLAG_UNCULLED)) {
         return true;
     } else {
         return false;

--- a/src/overlays/actors/ovl_En_Blkobj/z_en_blkobj.c
+++ b/src/overlays/actors/ovl_En_Blkobj/z_en_blkobj.c
@@ -95,7 +95,7 @@ void EnBlkobj_Wait(EnBlkobj* this, GlobalContext* globalCtx) {
 }
 
 void EnBlkobj_SpawnDarkLink(EnBlkobj* this, GlobalContext* globalCtx) {
-    if (!(this->dyna.actor.flags & ACTOR_FLAG_6)) {
+    if (!(this->dyna.actor.flags & ACTOR_FLAG_UNCULLED)) {
         Actor_Spawn(&globalCtx->actorCtx, globalCtx, ACTOR_EN_TORCH2, this->dyna.actor.world.pos.x,
                     this->dyna.actor.world.pos.y, this->dyna.actor.world.pos.z, 0, this->dyna.actor.yawTowardsPlayer, 0,
                     0);

--- a/src/overlays/actors/ovl_En_Horse/z_en_horse.c
+++ b/src/overlays/actors/ovl_En_Horse/z_en_horse.c
@@ -676,7 +676,7 @@ s32 func_80A5BBBC(GlobalContext* globalCtx, EnHorse* this, Vec3f* pos) {
         return false;
     }
     eyeDist = Math3D_Vec3f_DistXYZ(pos, &globalCtx->view.eye);
-    return func_800314D4(globalCtx, &this->actor, &sp24, sp20) || eyeDist < 100.0f;
+    return Actor_IsInUncullZone(globalCtx, &this->actor, &sp24, sp20) || eyeDist < 100.0f;
 }
 
 void EnHorse_IdleAnimSounds(EnHorse* this, GlobalContext* globalCtx) {

--- a/src/overlays/actors/ovl_En_Peehat/z_en_peehat.c
+++ b/src/overlays/actors/ovl_En_Peehat/z_en_peehat.c
@@ -993,7 +993,7 @@ void EnPeehat_Update(Actor* thisx, GlobalContext* globalCtx) {
             CollisionCheck_SetAC(globalCtx, &globalCtx->colChkCtx, &this->colQuad.base);
         }
         // if PEAHAT_TYPE_GROUNDED
-        if (thisx->params < 0 && (thisx->flags & ACTOR_FLAG_6)) {
+        if (thisx->params < 0 && (thisx->flags & ACTOR_FLAG_UNCULLED)) {
             for (i = 1; i >= 0; i--) {
                 Vec3f posResult;
                 CollisionPoly* poly = NULL;

--- a/src/overlays/actors/ovl_En_Tite/z_en_tite.c
+++ b/src/overlays/actors/ovl_En_Tite/z_en_tite.c
@@ -375,7 +375,7 @@ void EnTite_Attack(EnTite* this, GlobalContext* globalCtx) {
                     func_800355B8(globalCtx, &this->backLeftFootPos);
                 }
             }
-            if (!(this->collider.base.atFlags & AT_HIT) && (this->actor.flags & ACTOR_FLAG_6)) {
+            if (!(this->collider.base.atFlags & AT_HIT) && (this->actor.flags & ACTOR_FLAG_UNCULLED)) {
                 CollisionCheck_SetAT(globalCtx, &globalCtx->colChkCtx, &this->collider.base);
             } else {
                 Player* player = GET_PLAYER(globalCtx);

--- a/src/overlays/actors/ovl_En_Viewer/z_en_viewer.c
+++ b/src/overlays/actors/ovl_En_Viewer/z_en_viewer.c
@@ -193,7 +193,7 @@ void EnViewer_InitImpl(EnViewer* this, GlobalContext* globalCtx) {
 
     if (!Object_IsLoaded(&globalCtx->objectCtx, skelObjBankIndex) ||
         !Object_IsLoaded(&globalCtx->objectCtx, this->animObjBankIndex)) {
-        this->actor.flags &= ~ACTOR_FLAG_6;
+        this->actor.flags &= ~ACTOR_FLAG_UNCULLED;
         return;
     }
 

--- a/src/overlays/actors/ovl_En_Wood02/z_en_wood02.c
+++ b/src/overlays/actors/ovl_En_Wood02/z_en_wood02.c
@@ -323,7 +323,7 @@ void EnWood02_Update(Actor* thisx, GlobalContext* globalCtx2) {
 
     // Despawn extra trees in a group if out of range
     if ((this->spawnType == WOOD_SPAWN_SPAWNED) && (this->actor.parent != NULL)) {
-        if (!(this->actor.flags & ACTOR_FLAG_6)) {
+        if (!(this->actor.flags & ACTOR_FLAG_UNCULLED)) {
             new_var = this->unk_14E[0];
             phi_v0 = 0;
 

--- a/src/overlays/actors/ovl_player_actor/z_player.c
+++ b/src/overlays/actors/ovl_player_actor/z_player.c
@@ -14041,7 +14041,7 @@ void func_80852C50(GlobalContext* globalCtx, Player* this, CsCmdActorAction* arg
     }
 
     if (linkCsAction == NULL) {
-        this->actor.flags &= ~ACTOR_FLAG_6;
+        this->actor.flags &= ~ACTOR_FLAG_UNCULLED;
         return;
     }
 


### PR DESCRIPTION
Added the compiler flag NO_CULLING to ensure that objects stay visible even when the camera is far away.
This PR should work for all actors. So far, I have only tested it in Kakariko village with NPCs, bushes and chickens.