### PR TITLE
Removed illegal memory access

### DIFF
--- a/src/code/z_play.c
+++ b/src/code/z_play.c
@@ -375,7 +375,9 @@ void Gameplay_Init(GameState* thisx) {
     if ((gEntranceTable[((void)0, gSaveContext.entranceIndex)].scene == SCENE_SPOT09) &&
         gSaveContext.sceneSetupIndex == 6) {
         osSyncPrintf("エンディングはじまるよー\n"); // "The ending starts"
+#ifdef N64_VERSION
         ((void (*)())0x81000000)();
+#endif
         osSyncPrintf("出戻り？\n"); // "Return?"
     }
 

--- a/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
+++ b/src/overlays/gamestates/ovl_file_choose/z_file_choose.c
@@ -410,8 +410,9 @@ void FileChoose_PulsateCursor(GameState* thisx) {
 
     if (CHECK_BTN_ALL(debugInput->press.button, BTN_DLEFT)) {
         sramCtx->readBuff[SRAM_HEADER_LANGUAGE] = gSaveContext.language = LANGUAGE_ENG;
+#ifdef N64_VERSION
         *((u8*)0x80000002) = LANGUAGE_ENG;
-
+#endif
         SsSram_ReadWrite(OS_K1_TO_PHYSICAL(0xA8000000), sramCtx->readBuff, 3, OS_WRITE);
         osSyncPrintf("1:read_buff[]=%x, %x, %x, %x\n", sramCtx->readBuff[SRAM_HEADER_SOUND],
                      sramCtx->readBuff[SRAM_HEADER_ZTARGET], sramCtx->readBuff[SRAM_HEADER_LANGUAGE],
@@ -423,7 +424,9 @@ void FileChoose_PulsateCursor(GameState* thisx) {
                      sramCtx->readBuff[SRAM_HEADER_MAGIC]);
     } else if (CHECK_BTN_ALL(debugInput->press.button, BTN_DUP)) {
         sramCtx->readBuff[SRAM_HEADER_LANGUAGE] = gSaveContext.language = LANGUAGE_GER;
+#ifdef N64_VERSION
         *((u8*)0x80000002) = LANGUAGE_GER;
+#endif
 
         SsSram_ReadWrite(OS_K1_TO_PHYSICAL(0xA8000000), sramCtx->readBuff, 3, OS_WRITE);
         osSyncPrintf("1:read_buff[]=%x, %x, %x, %x\n", sramCtx->readBuff[SRAM_HEADER_SOUND],
@@ -435,7 +438,9 @@ void FileChoose_PulsateCursor(GameState* thisx) {
                      sramCtx->readBuff[SRAM_HEADER_MAGIC]);
     } else if (CHECK_BTN_ALL(debugInput->press.button, BTN_DRIGHT)) {
         sramCtx->readBuff[SRAM_HEADER_LANGUAGE] = gSaveContext.language = LANGUAGE_FRA;
+#ifdef N64_VERSION
         *((u8*)0x80000002) = LANGUAGE_FRA;
+#endif
 
         SsSram_ReadWrite(OS_K1_TO_PHYSICAL(0xA8000000), sramCtx->readBuff, 3, OS_WRITE);
         osSyncPrintf("1:read_buff[]=%x, %x, %x, %x\n", sramCtx->readBuff[SRAM_HEADER_SOUND],


### PR DESCRIPTION
The game writes to specific memory addresses to communicate with the emulator when it is running on Gamecube.
These lines cause a crash on PC.
Added the compiler flag N64_VERSION to re-enable these lines.