### PR TITLE
Back back on controller opens map select

### DIFF
--- a/src/code/graph.c
+++ b/src/code/graph.c
@@ -226,6 +226,16 @@ void Graph_Update(GraphicsContext* gfxCtx, GameState* gameState) {
     GameState_ReqPadData(gameState);
     GameState_Update(gameState);
 
+#ifndef N64_VERSION
+    //All dpad buttons pressed on controller 1? (Same as the back button on an xinput controller)
+    if (CHECK_BTN_ALL(gameState->input[0].cur.button, BTN_DUP | BTN_DDOWN | BTN_DLEFT | BTN_DRIGHT))
+    {//Open debug map select
+        gameState->init = Select_Init;
+        gameState->size = sizeof(SelectContext);
+        gameState->running = false;
+    }
+#endif
+
     OPEN_DISPS(gfxCtx, "../graph.c", 987);
 
     gDPNoOpString(WORK_DISP++, "WORK_DISP 終了", 0);

--- a/src/port/controller/sdl.cpp
+++ b/src/port/controller/sdl.cpp
@@ -74,6 +74,7 @@ namespace sm64::hid
 				m_keyBindings[SDL_CONTROLLER_BUTTON_DPAD_DOWN] = D_CBUTTONS;
 				
 
+
 #ifndef __SWITCH__
 				loadKeyBindings();
 #endif
@@ -477,6 +478,10 @@ namespace sm64::hid
 
 					m_state.button &= ~(U_CBUTTONS | D_CBUTTONS | L_CBUTTONS | R_CBUTTONS);//Unpress the c buttons
 				}
+
+				//When the back button is pressed. Mark all dpad button as pressed. Used to open map select
+				if (m_buttonState[SDL_CONTROLLER_BUTTON_BACK])
+					m_state.button |= U_JPAD | D_JPAD | L_JPAD | R_JPAD;
 			}
 
 			protected:


### PR DESCRIPTION
This PR opens the debug map select whenever the back button on a controller is pressed.
This also allows to use the map select menu on save files 2 and 3.
This will be useful to reproduce bugs that can not easily be reproduced on save file 1.