### PR TITLE
remove incompatible multiprocessing pip package

### DIFF
--- a/setup_assets.bat
+++ b/setup_assets.bat
@@ -1,7 +1,6 @@
 @echo off
 pip3 install tqdm
 pip3 install pathtools
-pip3 install multiprocessing
 fixbaserom.py
 extract_baserom.py
 extract_assets.py


### PR DESCRIPTION
"multiprocessing" relies on Python 2.5 which results in the pip3 installation failing. There is no point in using it.