### PR TITLE
Fixed gray icons in pause menu

### DIFF
--- a/include/def/code_80097A00.h
+++ b/include/def/code_80097A00.h
@@ -7,6 +7,10 @@ extern u8 gEquipShifts[4];
 extern u32 gGsFlagsMasks[4];
 extern u32 gGsFlagsShifts[4];
 extern void* gItemIcons[0x82];
+#ifndef N64_VERSION
+extern u8* gItemIconsGray[0x60][32*32];
+extern void* gItemIconsCurrent[0x82];//Points to either the original or the grayscale version
+#endif
 extern u8 gItemSlots[56];
 extern u16 gUpgradeCapacities[8][4];
 extern u32 gUpgradeMasks[8];

--- a/src/code/code_80097A00.c
+++ b/src/code/code_80097A00.c
@@ -179,6 +179,13 @@ void* gItemIcons[] = {
     gOcarinaATex,
 };
 
+//Copy of all the icon in grayscale version.
+//The texture here will be generated on runtime via KaleidoScope_GrayOutTextureRGBA32() inKaleidoScope_SetupGrayIcons()
+#ifndef N64_VERSION
+void* gItemIconsGray[0x60][32*32];
+void* gItemIconsCurrent[0x82];
+#endif
+
 // Used to map item IDs to inventory slots
 u8 gItemSlots[] = {
     SLOT_STICK,       SLOT_NUT,          SLOT_BOMB,        SLOT_BOW,         SLOT_ARROW_FIRE,  SLOT_DINS_FIRE,

--- a/src/code/game.c
+++ b/src/code/game.c
@@ -47,6 +47,8 @@ extern OSViMode osViModeMpalLan1;
 extern OSViMode osViModePalLan1;
 extern OSViMode osViModeFpalLan1;
 
+void KaleidoScope_SetupGrayIcons();
+
 f32 gViConfigXScale;
 f32 gViConfigYScale;
 u32 gViConfigFeatures;
@@ -456,6 +458,9 @@ void GameState_Init(GameState* gameState, GameStateFunc init, GraphicsContext* g
     endTime = osGetTime();
     // "gamealloc_init processing time %d us"
     osSyncPrintf("gamealloc_init processing time %d us\n", OS_CYCLES_TO_USEC(endTime - startTime));
+
+    //Generate grayscale versions of all icons
+    KaleidoScope_SetupGrayIcons();
 
     startTime = endTime;
     GameState_InitArena(gameState, 0x100000 * 0x30); // TODO FIX HACK

--- a/src/code/z_parameter.c
+++ b/src/code/z_parameter.c
@@ -3317,7 +3317,7 @@ void Interface_Draw(GlobalContext* globalCtx) {
                 gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 255, 255, 255, pauseCtx->equipAnimAlpha);
                 gSPVertex(OVERLAY_DISP++, &pauseCtx->cursorVtx[16], 4, 0);
 
-                gDPLoadTextureBlock(OVERLAY_DISP++, gItemIcons[pauseCtx->equipTargetItem], G_IM_FMT_RGBA, G_IM_SIZ_32b,
+                gDPLoadTextureBlock(OVERLAY_DISP++, gItemIconsCurrent[pauseCtx->equipTargetItem], G_IM_FMT_RGBA, G_IM_SIZ_32b,
                                     32, 32, 0, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMIRROR | G_TX_WRAP, G_TX_NOMASK,
                                     G_TX_NOMASK, G_TX_NOLOD, G_TX_NOLOD);
             } else {

--- a/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
+++ b/src/overlays/misc/ovl_kaleido_scope/z_kaleido_equipment.c
@@ -567,11 +567,11 @@ void KaleidoScope_DrawEquipment(GlobalContext* globalCtx) {
         for (k = 0, bit = rowStart, point = 4; k < 3; k++, point += 4, temp++, bit++) {
 
             if (((u32)i == 0) && (k == 2) && (gSaveContext.bgsFlag != 0)) {
-                KaleidoScope_DrawQuadTextureRGBA32(globalCtx->state.gfxCtx, gBiggoronSwordIconTex, 32, 32, point);
+                KaleidoScope_DrawQuadTextureRGBA32(globalCtx->state.gfxCtx, gItemIconsCurrent[ITEM_SWORD_BROKEN], 32, 32, point);
             } else if ((i == 0) && (k == 2) && (gBitFlags[bit + 1] & gSaveContext.inventory.equipment)) {
-                KaleidoScope_DrawQuadTextureRGBA32(globalCtx->state.gfxCtx, gBrokenGiantsKnifeIconTex, 32, 32, point);
+                KaleidoScope_DrawQuadTextureRGBA32(globalCtx->state.gfxCtx, gItemIconsCurrent[ITEM_SWORD_BGS], 32, 32, point);
             } else if (gBitFlags[bit] & gSaveContext.inventory.equipment) {
-                KaleidoScope_DrawQuadTextureRGBA32(globalCtx->state.gfxCtx, gItemIcons[ITEM_SWORD_KOKIRI + temp], 32,
+                KaleidoScope_DrawQuadTextureRGBA32(globalCtx->state.gfxCtx, gItemIconsCurrent[ITEM_SWORD_KOKIRI + temp], 32,
                                                    32, point);
             }
         }

--- a/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
+++ b/src/overlays/misc/ovl_kaleido_scope/z_kaleido_item.c
@@ -470,7 +470,7 @@ void KaleidoScope_DrawItemSelect(GlobalContext* globalCtx) {
             }
 
             gSPVertex(POLY_OPA_DISP++, &pauseCtx->itemVtx[j + 0], 4, 0);
-            KaleidoScope_DrawQuadTextureRGBA32(globalCtx->state.gfxCtx, gItemIcons[gSaveContext.inventory.items[i]], 32,
+            KaleidoScope_DrawQuadTextureRGBA32(globalCtx->state.gfxCtx, gItemIconsCurrent[gSaveContext.inventory.items[i]], 32,
                                                32, 0);
         }
     }


### PR DESCRIPTION
I rewrote `KaleidoScope_GrayOutTextureRGBA32()` (for big and little endian).
Added another version of `KaleidoScope_GrayOutTextureRGBA32` that takes an input and output texture.

Gray icons will now be generated once at game startup in `KaleidoScope_SetupGrayIcons()`.
I keep track about which texture to use in `gItemIconsCurrent` (updated every frame).