### PR TITLE
Force 4:3 for Prerendered Backgrounds

### DIFF
--- a/src/code/z_play.c
+++ b/src/code/z_play.c
@@ -75,6 +75,8 @@
 #include "def/z_vr_box_draw.h"
 #include "def/zbuffer.h"
 
+void gfx_force_43(bool enable);//From GlideN64
+
 void Gameplay_Main(GameState* thisx);
 void Gameplay_SpawnScene(GlobalContext* globalCtx, s32 sceneNum, s32 spawn);
 
@@ -455,6 +457,11 @@ void Gameplay_Init(GameState* thisx) {
     while (!func_800973FC(globalCtx, &globalCtx->roomCtx)) {
         ; // Empty Loop
     }
+
+    //Check if the room in our scene has a prerendered backgrounds
+    Room* currentRoom = &globalCtx->roomCtx.curRoom;
+    PolygonType1* polygon1 = &currentRoom->mesh->polygon1;
+    gfx_force_43(polygon1->format == 1);//Switch GLideN64 to 4:3 if necessary
 
     player = GET_PLAYER(globalCtx);
     Camera_InitPlayerSettings(&globalCtx->mainCamera, player);

--- a/vs/GLideN64.vcxproj
+++ b/vs/GLideN64.vcxproj
@@ -183,7 +183,7 @@ copy /Y "$(OutDir)$(TargetName).*" "$(PJ64PluginsDirWTL_x64)")</Command>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug_mupenplus' Or '$(Configuration)'=='Release_mupenplus'">
     <ClCompile>
-      <PreprocessorDefinitions>NATIVE;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NATIVE;NO_LOAD_PROGRESS_DISPLAY;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <PostBuildEvent>
       <Message>Copy result to plugins folder</Message>


### PR DESCRIPTION
This PR switches GLideN64 into a 4:3 aspect ratio when a scene is loaded which contains a prerendered background.
`gfx_force_43(bool)` was added to GLideN64.