### PR TITLE
No console window for Release builds

### DIFF
--- a/vs/OOT.vcxproj
+++ b/vs/OOT.vcxproj
@@ -134,7 +134,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
-      <SubSystem>Console</SubSystem>
+      <SubSystem>Windows</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -170,7 +170,7 @@
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
     </ClCompile>
     <Link>
-      <SubSystem>Console</SubSystem>
+      <SubSystem>Windows</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/vs/libGLideNHQ.vcxproj
+++ b/vs/libGLideNHQ.vcxproj
@@ -126,7 +126,7 @@
   <ItemDefinitionGroup Condition="('$(Configuration)'=='Release') And '$(Platform)'=='Win32'">
     <Lib>
       <AdditionalLibraryDirectories Condition="'$(MSBuildAssemblyVersion)'=='12.0'">lib/msvc12/rel</AdditionalLibraryDirectories>
-      <AdditionalLibraryDirectories Condition="'$(MSBuildAssemblyVersion)'!='12.0'">lib/rel</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories Condition="'$(MSBuildAssemblyVersion)'!='12.0'">../GLideN64/projects/msvc/lib/rel</AdditionalLibraryDirectories>
     </Lib>
     <ClCompile>
       <ConformanceMode Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</ConformanceMode>


### PR DESCRIPTION
I believe this PR fixes issue #60.
I switched `/subsystem:console` to `/subsystem:windows` for release builds.

Release builds should definitely not have a console window.
For debug builds , I often find the console helpful for debugging.