### PR TITLE
fix osSyncPrintf crash

### DIFF
--- a/src/code/z_camera.cpp
+++ b/src/code/z_camera.cpp
@@ -5586,8 +5586,8 @@ s32 Camera_Demo1(Camera* camera) {
             anim->curFrame = 0.0f;
             camera->animState++;
             // "absolute" : "relative"
-            osSyncPrintf(VT_SGR("1") "%06u:" VT_RST " camera: spline demo: start %s \n",
-                         camera->globalCtx->state.frames, *relativeToPlayer == 0 ? "absolute" : "relative");
+            //osSyncPrintf(VT_SGR("1") "%06u:" VT_RST " camera: spline demo: start %s \n",
+                         //camera->globalCtx->state.frames, *relativeToPlayer == 0 ? "absolute" : "relative");
 
             if (PREG(93)) {
                 Camera_DebugPrintSplineArray("CENTER", 5, csAtPoints);
@@ -7644,7 +7644,7 @@ s32 Camera_ChangeModeFlags(Camera* camera, s16 mode, u8 flags) {
     static s32 modeChangeFlags = 0;
 
     if (QREG(89)) {
-        osSyncPrintf("+=+(%d)+=+ recive request -> %s\n", camera->globalCtx->state.frames, sCameraModeNames[mode]);
+        //osSyncPrintf("+=+(%d)+=+ recive request -> %s\n", camera->globalCtx->state.frames, sCameraModeNames[mode]);
     }
 
     if (camera->unk_14C & 0x20 && flags == 0) {
@@ -7840,8 +7840,8 @@ s16 Camera_ChangeSettingFlags(Camera* camera, s16 setting, s16 flags) {
         Camera_CopyModeValuesToPREG(camera, camera->mode);
     }
 
-    osSyncPrintf(VT_SGR("1") "%06u:" VT_RST " camera: change camera[%d] set %s\n", camera->globalCtx->state.frames.whole(),
-                 camera->thisIdx, sCameraSettingNames[camera->setting]);
+    //osSyncPrintf(VT_SGR("1") "%06u:" VT_RST " camera: change camera[%d] set %s\n", camera->globalCtx->state.frames.whole(),
+                 //camera->thisIdx, sCameraSettingNames[camera->setting]);
 
     return setting;
 }

--- a/src/code/z_onepointdemo.cpp
+++ b/src/code/z_onepointdemo.cpp
@@ -1326,13 +1326,13 @@ s32 OnePointCutscene_Attention(GlobalContext* globalCtx, Actor* actor) {
         case ACTORCAT_MISC:
         case ACTORCAT_BOSS:
         default:
-            osSyncPrintf(VT_COL(YELLOW, BLACK) "actor attention demo camera: %d: unkown part of actor %d\n" VT_RST,
-                         globalCtx->state.frames, actor->category);
+            //osSyncPrintf(VT_COL(YELLOW, BLACK) "actor attention demo camera: %d: unkown part of actor %d\n" VT_RST,
+                         //globalCtx->state.frames, actor->category);
             timer = 30;
             break;
     }
-    osSyncPrintf(VT_FGCOL(CYAN) "%06u:" VT_RST " actor attention demo camera: request %d ", globalCtx->state.frames,
-                 actor->category);
+    //osSyncPrintf(VT_FGCOL(CYAN) "%06u:" VT_RST " actor attention demo camera: request %d ", globalCtx->state.frames,
+                 //actor->category);
 
     // If the previous attention cutscene has an actor in the same category, skip this actor.
     if (actor->category == vLastHigherCat) {

--- a/src/overlays/actors/ovl_Obj_Timeblock/z_obj_timeblock.cpp
+++ b/src/overlays/actors/ovl_Obj_Timeblock/z_obj_timeblock.cpp
@@ -224,7 +224,7 @@ void ObjTimeblock_Normal(ObjTimeblock* pthis, GlobalContext* globalCtx) {
         // Possibly points the camera to pthis actor
         OnePointCutscene_Attention(globalCtx, &pthis->dyna.actor);
         // "◯◯◯◯ Time Block Attention Camera (frame counter  %d)\n"
-        osSyncPrintf("◯◯◯◯ Time Block 注目カメラ (frame counter  %d)\n", globalCtx->state.frames);
+        //osSyncPrintf("◯◯◯◯ Time Block 注目カメラ (frame counter  %d)\n", globalCtx->state.frames);
 
         pthis->demoEffectFirstPartTimer = 12;
 
@@ -282,7 +282,7 @@ void ObjTimeblock_AltBehaviorVisible(ObjTimeblock* pthis, GlobalContext* globalC
         pthis->demoEffectTimer = 160;
         OnePointCutscene_Attention(globalCtx, &pthis->dyna.actor);
         // "Time Block Attention Camera (frame counter)"
-        osSyncPrintf("◯◯◯◯ Time Block 注目カメラ (frame counter  %d)\n", globalCtx->state.frames);
+        //osSyncPrintf("◯◯◯◯ Time Block 注目カメラ (frame counter  %d)\n", globalCtx->state.frames);
         ObjTimeblock_ToggleSwitchFlag(globalCtx, pthis->dyna.actor.params & 0x3F);
     }
 

--- a/src/port/ultra_reimplementation.cpp
+++ b/src/port/ultra_reimplementation.cpp
@@ -379,7 +379,7 @@ static char buffer[0x10000];
 
 void osSyncPrintf(const char* fmt, ...)
 {
-	return; // temp disable this, because osSyncPrintf is not type safe, and globalCtx->state.frames gets passed to it as an object instead of expected int and it crashes
+	//return; // temp disable this, because osSyncPrintf is not type safe, and globalCtx->state.frames gets passed to it as an object instead of expected int and it crashes
 	memset(buffer, 0, sizeof(buffer));
 	va_list arg;
 	int done;


### PR DESCRIPTION
Commented out all (?) `osSyncPrintf` calls, which uses `globalCtx->state.frames` as a parameter, so it shouldn't crash anymore.