### PR TITLE
Fixed Fullscreen Effects

### DIFF
--- a/src/code/z_fbdemo_circle.cpp
+++ b/src/code/z_fbdemo_circle.cpp
@@ -5,6 +5,12 @@
 #include "z64audio.h"
 #include "sfx.h"
 
+extern "C"
+{
+	u64 gfx_width();
+	u64 gfx_height();
+}
+
 // unused
 Gfx sCircleNullDList[] = {
     gsSPEndDisplayList(),
@@ -152,7 +158,12 @@ void TransitionCircle_Draw(void* thisx, Gfx** gfxP) {
     // These variables are a best guess based on the other transition types.
     f32 tPos = 0.0f;
     f32 rot = 0.0f;
+#ifdef N64_VERSION
     f32 scale = 14.8f;
+#else
+    const float correction_factor = (gfx_width() * 3.0f) / (gfx_height() * 4.0f); // Should be 1 on a 4:3 display
+    f32 scale			  = 14.8f * correction_factor;
+#endif
 
     modelView = pthis->modelView[pthis->frame];
 

--- a/src/code/z_fbdemo_circle.cpp
+++ b/src/code/z_fbdemo_circle.cpp
@@ -162,7 +162,7 @@ void TransitionCircle_Draw(void* thisx, Gfx** gfxP) {
     f32 scale = 14.8f;
 #else
     const float correction_factor = (gfx_width() * 3.0f) / (gfx_height() * 4.0f); // Should be 1 on a 4:3 display
-    f32 scale			  = 14.8f * correction_factor;
+    f32 scale = 14.8f * correction_factor;
 #endif
 
     modelView = pthis->modelView[pthis->frame];

--- a/src/code/z_fbdemo_circle.cpp
+++ b/src/code/z_fbdemo_circle.cpp
@@ -4,12 +4,7 @@
 #include "z64transition.h"
 #include "z64audio.h"
 #include "sfx.h"
-
-extern "C"
-{
-	u64 gfx_width();
-	u64 gfx_height();
-}
+#include "gfx_align.h"
 
 // unused
 Gfx sCircleNullDList[] = {
@@ -158,12 +153,8 @@ void TransitionCircle_Draw(void* thisx, Gfx** gfxP) {
     // These variables are a best guess based on the other transition types.
     f32 tPos = 0.0f;
     f32 rot = 0.0f;
-#ifdef N64_VERSION
-    f32 scale = 14.8f;
-#else
     const float correction_factor = (gfx_width() * 3.0f) / (gfx_height() * 4.0f); // Should be 1 on a 4:3 display
     f32 scale = 14.8f * correction_factor;
-#endif
 
     modelView = pthis->modelView[pthis->frame];
 

--- a/src/overlays/actors/ovl_Oceff_Wipe2/z_oceff_wipe2.cpp
+++ b/src/overlays/actors/ovl_Oceff_Wipe2/z_oceff_wipe2.cpp
@@ -15,12 +15,7 @@
 #include "def/z_lib.h"
 #include "def/z_parameter.h"
 #include "def/z_rcp.h"
-
-extern "C"
-{
-	u64 gfx_width();
-	u64 gfx_height();
-}
+#include "gfx_align.h"
 
 #define FLAGS (ACTOR_FLAG_4 | ACTOR_FLAG_25)
 
@@ -109,12 +104,8 @@ void OceffWipe2_Draw(Actor* thisx, GlobalContext* globalCtx) {
     func_80093D84(globalCtx->state.gfxCtx);
 
     Matrix_Translate(eye.x + vec.x, eye.y + vec.y, eye.z + vec.z, MTXMODE_NEW);
-#ifdef N64_VERSION
-    Matrix_Scale(0.1f, 0.1f, 0.1f, MTXMODE_APPLY);
-#else
     const float correction_factor = (gfx_width() * 3.0f) / (gfx_height() * 4.0f); // Should be 1 on a 4:3 display
     Matrix_Scale(0.1f * correction_factor, 0.1f, 0.1f, MTXMODE_APPLY);
-#endif
     func_800D1FD4(&globalCtx->billboardMtxF);
     Matrix_Translate(0.0f, 0.0f, -z, MTXMODE_APPLY);
 

--- a/src/overlays/actors/ovl_Oceff_Wipe2/z_oceff_wipe2.cpp
+++ b/src/overlays/actors/ovl_Oceff_Wipe2/z_oceff_wipe2.cpp
@@ -16,6 +16,12 @@
 #include "def/z_parameter.h"
 #include "def/z_rcp.h"
 
+extern "C"
+{
+	u64 gfx_width();
+	u64 gfx_height();
+}
+
 #define FLAGS (ACTOR_FLAG_4 | ACTOR_FLAG_25)
 
 void OceffWipe2_Init(Actor* thisx, GlobalContext* globalCtx);
@@ -103,7 +109,12 @@ void OceffWipe2_Draw(Actor* thisx, GlobalContext* globalCtx) {
     func_80093D84(globalCtx->state.gfxCtx);
 
     Matrix_Translate(eye.x + vec.x, eye.y + vec.y, eye.z + vec.z, MTXMODE_NEW);
+#ifdef N64_VERSION
     Matrix_Scale(0.1f, 0.1f, 0.1f, MTXMODE_APPLY);
+#else
+    const float correction_factor = (gfx_width() * 3.0f) / (gfx_height() * 4.0f); // Should be 1 on a 4:3 display
+    Matrix_Scale(0.1f * correction_factor, 0.1f, 0.1f, MTXMODE_APPLY);
+#endif
     func_800D1FD4(&globalCtx->billboardMtxF);
     Matrix_Translate(0.0f, 0.0f, -z, MTXMODE_APPLY);
 

--- a/src/overlays/actors/ovl_Oceff_Wipe3/z_oceff_wipe3.cpp
+++ b/src/overlays/actors/ovl_Oceff_Wipe3/z_oceff_wipe3.cpp
@@ -15,12 +15,7 @@
 #include "def/z_lib.h"
 #include "def/z_parameter.h"
 #include "def/z_rcp.h"
-
-extern "C"
-{
-	u64 gfx_width();
-	u64 gfx_height();
-}
+#include "gfx_align.h"
 
 #define FLAGS (ACTOR_FLAG_4 | ACTOR_FLAG_25)
 
@@ -110,12 +105,8 @@ void OceffWipe3_Draw(Actor* thisx, GlobalContext* globalCtx) {
     func_80093D84(globalCtx->state.gfxCtx);
 
     Matrix_Translate(eye.x + vec.x, eye.y + vec.y, eye.z + vec.z, MTXMODE_NEW);
-#ifdef N64_VERSION
-    Matrix_Scale(0.1f, 0.1f, 0.1f, MTXMODE_APPLY);
-#else
     const float correction_factor = (gfx_width() * 3.0f) / (gfx_height() * 4.0f); // Should be 1 on a 4:3 display
     Matrix_Scale(0.1f * correction_factor, 0.1f, 0.1f, MTXMODE_APPLY);
-#endif
     func_800D1FD4(&globalCtx->billboardMtxF);
     Matrix_Translate(0.0f, 0.0f, -z, MTXMODE_APPLY);
 

--- a/src/overlays/actors/ovl_Oceff_Wipe3/z_oceff_wipe3.cpp
+++ b/src/overlays/actors/ovl_Oceff_Wipe3/z_oceff_wipe3.cpp
@@ -16,6 +16,12 @@
 #include "def/z_parameter.h"
 #include "def/z_rcp.h"
 
+extern "C"
+{
+	u64 gfx_width();
+	u64 gfx_height();
+}
+
 #define FLAGS (ACTOR_FLAG_4 | ACTOR_FLAG_25)
 
 void OceffWipe3_Init(Actor* thisx, GlobalContext* globalCtx);
@@ -104,7 +110,12 @@ void OceffWipe3_Draw(Actor* thisx, GlobalContext* globalCtx) {
     func_80093D84(globalCtx->state.gfxCtx);
 
     Matrix_Translate(eye.x + vec.x, eye.y + vec.y, eye.z + vec.z, MTXMODE_NEW);
+#ifdef N64_VERSION
     Matrix_Scale(0.1f, 0.1f, 0.1f, MTXMODE_APPLY);
+#else
+    const float correction_factor = (gfx_width() * 3.0f) / (gfx_height() * 4.0f); // Should be 1 on a 4:3 display
+    Matrix_Scale(0.1f * correction_factor, 0.1f, 0.1f, MTXMODE_APPLY);
+#endif
     func_800D1FD4(&globalCtx->billboardMtxF);
     Matrix_Translate(0.0f, 0.0f, -z, MTXMODE_APPLY);
 


### PR DESCRIPTION
For the fade effect I scaled it in the X an Y direction. This also effects the penumbra

![image](https://user-images.githubusercontent.com/35939509/154773094-59357c37-be28-4fe7-9e51-11d674e58082.png)
Compare it to 4:3
![image](https://user-images.githubusercontent.com/35939509/154773127-1605a68f-8b63-4079-979c-1b238859a4b5.png)

For Saria's song and Epona's song I scaled it in the X direction (for non 4:3 aspect ratios)
![image](https://user-images.githubusercontent.com/35939509/154773210-87ac865b-2113-411b-9159-4b7382cdb017.png)

Zelda's lullaby also seems also broken but only on very wide screens.
The Scarecrow song might break on 16:9. Did not fix since I could not find a setup to test the song,

There are also other fullscreen effects like a warp and an unused triforce effect. I will fix them as soon as a good setup is found.
