### PR TITLE
Forest Temple Door Fix

### DIFF
--- a/include/z64scene.h
+++ b/include/z64scene.h
@@ -298,7 +298,7 @@ enum SceneID {
     /* 0x00 */ SCENE_YDAN,
     /* 0x01 */ SCENE_DDAN,
     /* 0x02 */ SCENE_BDAN,
-    /* 0x03 */ SCENE_BMORI1,
+    /* 0x03 */ SCENE_BMORI1,//Forest temple
     /* 0x04 */ SCENE_HIDAN,
     /* 0x05 */ SCENE_MIZUSIN,
     /* 0x06 */ SCENE_JYASINZOU,

--- a/src/overlays/actors/ovl_En_Door/z_en_door.cpp
+++ b/src/overlays/actors/ovl_En_Door/z_en_door.cpp
@@ -65,6 +65,7 @@ static EnDoorInfo sDoorInfo[] = {
     { SCENE_MIZUSIN, 2, OBJECT_MIZU_OBJECTS },
     { SCENE_HAKADAN, 3, OBJECT_HAKA_DOOR },
     { SCENE_HAKADANCH, 3, OBJECT_HAKA_DOOR },
+    { SCENE_BMORI1, 0, OBJECT_GAMEPLAY_KEEP },//Doors in the forest temple. Might be incorrect
     // KEEP objects should remain last and in pthis order
     { -1, 0, OBJECT_GAMEPLAY_KEEP },
     { -1, 4, OBJECT_GAMEPLAY_FIELD_KEEP },
@@ -101,11 +102,14 @@ void EnDoor_Init(Actor* thisx, GlobalContext* globalCtx2) {
     objectInfo = &sDoorInfo[0];
     Actor_ProcessInitChain(&pthis->actor, sInitChain);
     SkelAnime_Init(globalCtx, &pthis->skelAnime, &gDoorSkel, &gDoor3Anim, pthis->jointTable, pthis->morphTable, 5);
+
+    // Find the correct door depending on the scene number
     for (i = 0; i < ARRAY_COUNT(sDoorInfo) - 2; i++, objectInfo++) {
         if (globalCtx->sceneNum == objectInfo->sceneNum) {
             break;
         }
     }
+    // Not found in the sDoorInfo array
     if (i >= ARRAY_COUNT(sDoorInfo) - 2 && Object_GetIndex(&globalCtx->objectCtx, OBJECT_GAMEPLAY_FIELD_KEEP) >= 0) {
         objectInfo++;
     }

--- a/src/overlays/actors/ovl_En_Door/z_en_door.cpp
+++ b/src/overlays/actors/ovl_En_Door/z_en_door.cpp
@@ -65,7 +65,9 @@ static EnDoorInfo sDoorInfo[] = {
     { SCENE_MIZUSIN, 2, OBJECT_MIZU_OBJECTS },
     { SCENE_HAKADAN, 3, OBJECT_HAKA_DOOR },
     { SCENE_HAKADANCH, 3, OBJECT_HAKA_DOOR },
+#ifdef N64_VERSION
     { SCENE_BMORI1, 0, OBJECT_GAMEPLAY_KEEP },//Doors in the forest temple. Might be incorrect
+#endif
     // KEEP objects should remain last and in pthis order
     { -1, 0, OBJECT_GAMEPLAY_KEEP },
     { -1, 4, OBJECT_GAMEPLAY_FIELD_KEEP },


### PR DESCRIPTION
In `EnDoor_Init` for the forest temple the wrong type was chosen.
This happens because
`Object_GetIndex(&globalCtx->objectCtx, OBJECT_GAMEPLAY_FIELD_KEEP) >= 0`
is always true, since we changed `Object_GetIndex`.
I added an entry to `sDoorInfo` in order to fix that.