### PR TITLE
Fixed Pixel Format Error

### DIFF
--- a/src/port/window/sdl/window_sdl2.cpp
+++ b/src/port/window/sdl/window_sdl2.cpp
@@ -198,7 +198,6 @@ namespace platform::window
 		{
 			SDL_Init(SDL_INIT_VIDEO);
 
-			SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24);
 			// SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
 
 			// SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 1);


### PR DESCRIPTION
This fixes the pixel format error message box by removing the line of code that was causing SetPixelFormat to fail when GildeN64 uses it.