### PR TITLE
Changed Platform Toolset of Visual Studio to be Default

### DIFF
--- a/vs/OOT.vcxproj
+++ b/vs/OOT.vcxproj
@@ -27,7 +27,7 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>$(DefaultPlatformToolset)</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />


### PR DESCRIPTION
This changes the Platform Toolset of the OOT.sln to use $(DefaultPlatformToolset) in order to get it working with newer Visual Studio versions.