### PR TITLE
Fixed the memory problem in the forest temple (again)

### DIFF
--- a/src/code/z_bgcheck.cpp
+++ b/src/code/z_bgcheck.cpp
@@ -1458,31 +1458,6 @@ s32 BgCheck_IsSpotScene(GlobalContext* globalCtx) {
     return false;
 }
 
-typedef struct {
-    s16 sceneId;
-    u32 memSize;
-} BgCheckSceneMemEntry;
-
-/**
- * Get custom scene memSize
- */
-s32 BgCheck_TryGetCustomMemsize(s32 sceneId, u32* memSize) {
-    static BgCheckSceneMemEntry sceneMemList[] = {
-        { SCENE_SPOT00, 0xB798 },     { SCENE_GANON_FINAL, 0x78C8 }, { SCENE_GANON_DEMO, 0x70C8 },
-        { SCENE_JYASINBOSS, 0xACC8 }, { SCENE_KENJYANOMA, 0x70C8 },  { SCENE_JYASINZOU, 0x16CC8 },
-        { SCENE_HIDAN, 0x198C8 },     { SCENE_GANON_BOSS, 0x84C8 },
-    };
-    s32 i;
-
-    for (i = 0; i < ARRAY_COUNT(sceneMemList); i++) {
-        if (sceneId == sceneMemList[i].sceneId) {
-            *memSize = sceneMemList[i].memSize;
-            return true;
-        }
-    }
-    return false;
-}
-
 /**
  * Compute subdivLength for scene mesh lookup, for a single dimension
  */
@@ -1552,16 +1527,13 @@ void BgCheck_Allocate(CollisionContext* colCtx, GlobalContext* globalCtx, Collis
         colCtx->subdivAmount.y = 4;
         colCtx->subdivAmount.z = 16;
     } else {
-        if (BgCheck_TryGetCustomMemsize(globalCtx->sceneNum, &customMemSize)) {
-            colCtx->memSize = customMemSize;
-        } else {
-            colCtx->memSize = 0x1CC00;
-        }
+        colCtx->memSize = 0x1CC00;
+
         // "/* BGCheck Normal Size %dbyte  */\n"
         osSyncPrintf("/* BGCheck Normal Size %dbyte  */\n", colCtx->memSize);
-        colCtx->dyna.polyNodesMax = 1000;
-        colCtx->dyna.polyListMax = 512;
-        colCtx->dyna.vtxListMax = 512;
+        colCtx->dyna.polyNodesMax = 1000 + 512;
+        colCtx->dyna.polyListMax  = 512  + 512;
+        colCtx->dyna.vtxListMax   = 512  + 512;
         useCustomSubdivisions = false;
 
         for (i = 0; i < ARRAY_COUNT(sceneSubdivisionList); i++) {


### PR DESCRIPTION
This PR again changes the amount of memory that is requested to fix the forest temple.
I got rid of `BgCheck_TryGetCustomMemsize` I reserve now the maximum of what was requested before.

My previous commit caused an assert when entering the Spirit Temple.
This one does not.
I tested all 100 or so scenes in the debug menu and played through 50% of the forest temple.
I recommend to further test this PR before merging.