### PR TITLE
Changed implementation of osGetTime()

### DIFF
--- a/src/port/ultra_reimplementation.cpp
+++ b/src/port/ultra_reimplementation.cpp
@@ -77,7 +77,7 @@ s32 osJamMesg(UNUSED OSMesgQueue* mq, UNUSED OSMesg msg, UNUSED s32 flag)
 
 OSTime osGetTime(void)
 {
-	return GetTickCount64();
+	return timeGetTime();
 }
 #else
 OSTime osGetTime(void)


### PR DESCRIPTION
Replaced GetTickCount64 with timeGetTime.
GetTickCount64 only has an accuracy of around 16ms.
This is barely enough to be accurate enough for rumble.
timeGetTime has an accuracy of around 1ms.

As an added bonus timeGetTime is available on more versions of Windows.