### PR TITLE
Close #185: fix flipped G and B values for A button color in ocarina

### DIFF
--- a/src/code/z_message_PAL.cpp
+++ b/src/code/z_message_PAL.cpp
@@ -176,8 +176,8 @@ void Message_ResetOcarinaNoteState(void) {
         sOcarinaNotesAlphaValues[3] = sOcarinaNotesAlphaValues[4] = sOcarinaNotesAlphaValues[5] =
             sOcarinaNotesAlphaValues[6] = sOcarinaNotesAlphaValues[7] = sOcarinaNotesAlphaValues[8] = 0;
     sOcarinaNoteAPrimR = 80;
-    sOcarinaNoteAPrimG = 255;
-    sOcarinaNoteAPrimB = 150;
+    sOcarinaNoteAPrimG = 150;
+    sOcarinaNoteAPrimB = 255;
     sOcarinaNoteAEnvR = 10;
     sOcarinaNoteAEnvG = 10;
     sOcarinaNoteAEnvB = 10;


### PR DESCRIPTION
Looks like B and G values got flipped. Reversing them results in correct colors (when compared to screenshots)

closes #185 

props to @bcary for helping me with debugging