### PR TITLE
Close #197 - Centered Carrots on Horses

### DIFF
--- a/src/code/z_message_PAL.cpp
+++ b/src/code/z_message_PAL.cpp
@@ -176,8 +176,8 @@ void Message_ResetOcarinaNoteState(void) {
         sOcarinaNotesAlphaValues[3] = sOcarinaNotesAlphaValues[4] = sOcarinaNotesAlphaValues[5] =
             sOcarinaNotesAlphaValues[6] = sOcarinaNotesAlphaValues[7] = sOcarinaNotesAlphaValues[8] = 0;
     sOcarinaNoteAPrimR = 80;
-    sOcarinaNoteAPrimG = 255;
-    sOcarinaNoteAPrimB = 150;
+    sOcarinaNoteAPrimG = 150;
+    sOcarinaNoteAPrimB = 255;
     sOcarinaNoteAEnvR = 10;
     sOcarinaNoteAEnvG = 10;
     sOcarinaNoteAEnvB = 10;

--- a/src/code/z_parameter.cpp
+++ b/src/code/z_parameter.cpp
@@ -3365,7 +3365,7 @@ void Interface_Draw(GlobalContext* globalCtx) {
                                         G_TX_NOLOD, G_TX_NOLOD);
 
                     // Draw 6 carrots
-                    for (svar1 = 1, svar5 = GFX_ALIGN_LEFT(ZREG(14)); svar1 < 7; svar1++, svar5 += 16) {
+                    for (svar1 = 1, svar5 = 110; svar1 < 7; svar1++, svar5 += 16) { // this took me three hours to figure out please dont laugh
                         // Carrot Color (based on availability)
                         if ((interfaceCtx->numHorseBoosts == 0) || (interfaceCtx->numHorseBoosts < svar1)) {
                             gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 0, 150, 255, interfaceCtx->aAlpha);

--- a/src/code/z_parameter.cpp
+++ b/src/code/z_parameter.cpp
@@ -3365,7 +3365,7 @@ void Interface_Draw(GlobalContext* globalCtx) {
                                         G_TX_NOLOD, G_TX_NOLOD);
 
                     // Draw 6 carrots
-                    for (svar1 = 1, svar5 = 110; svar1 < 7; svar1++, svar5 += 16) { // this took me three hours to figure out please dont laugh
+                    for (svar1 = 1, svar5 = ZREG(14); svar1 < 7; svar1++, svar5 += 16) { // this took me three hours to figure out please dont laugh
                         // Carrot Color (based on availability)
                         if ((interfaceCtx->numHorseBoosts == 0) || (interfaceCtx->numHorseBoosts < svar1)) {
                             gDPSetPrimColor(OVERLAY_DISP++, 0, 0, 0, 150, 255, interfaceCtx->aAlpha);


### PR DESCRIPTION
In theory, GFX_ALIGN_LEFT(X) should just always return X...it multiplies the screen height by the aspect, and subtracts it from the width. this should always be 0 (since height is width divided by aspect) plus the offset (X)

When I changed GFX_DIMENSIONS_FROM_LEFT_EDGE to use gfx_width() instead of SCREEN_WIDTH the carrots centered, but the HUD was centered as if rendering in 4:3, not in the actual screen corners. 

So the function context assumes 4:3 at 320x240, so 110 is always the correct value. Some other layer is repositioning those HUD elements later in the chain. 

anyway, 6 hours and a total of 9 bytes contributed over 2 PRs :D

Closes #197 