### PR TITLE
Increased memory of display lists

### DIFF
--- a/include/gfx.h
+++ b/include/gfx.h
@@ -61,11 +61,10 @@ struct GraphicsContext {
 
 struct GfxPool {
     /* 0x00000 */ u16 headMagic; // GFXPOOL_HEAD_MAGIC
-    /* 0x00008 */ Gfx polyOpaBuffer[0x17E0];
-    /* 0x0BF08 */ Gfx polyXluBuffer[0x800];
-    /* 0x0FF08 */ Gfx overlayBuffer[0x400];
-    /* 0x11F08 */ Gfx workBuffer[0x80];
-    /* 0x11308 */ Gfx unusedBuffer[0x20];
+    /* 0x00008 */ Gfx polyOpaBuffer[0x17E0*2];
+    /* 0x0BF08 */ Gfx polyXluBuffer[0x800*2];
+    /* 0x0FF08 */ Gfx overlayBuffer[0x400*2];
+    /* 0x11F08 */ Gfx workBuffer[0x80*2];
     /* 0x12408 */ u16 tailMagic; // GFXPOOL_TAIL_MAGIC
 };                       // size = 0x12410
 

--- a/include/gfx.h
+++ b/include/gfx.h
@@ -61,10 +61,10 @@ struct GraphicsContext {
 
 struct GfxPool {
     /* 0x00000 */ u16 headMagic; // GFXPOOL_HEAD_MAGIC
-    /* 0x00008 */ Gfx polyOpaBuffer[0x17E0*2];
-    /* 0x0BF08 */ Gfx polyXluBuffer[0x800*2];
-    /* 0x0FF08 */ Gfx overlayBuffer[0x400*2];
-    /* 0x11F08 */ Gfx workBuffer[0x80*2];
+    /* 0x00008 */ Gfx polyOpaBuffer[0x17E0*2]; // TODO FIX HACK
+    /* 0x0BF08 */ Gfx polyXluBuffer[0x800*2]; // TODO FIX HACK
+    /* 0x0FF08 */ Gfx overlayBuffer[0x400*2]; // TODO FIX HACK
+    /* 0x11F08 */ Gfx workBuffer[0x80*2]; // TODO FIX HACK
     /* 0x12408 */ u16 tailMagic; // GFXPOOL_TAIL_MAGIC
 };                       // size = 0x12410
 


### PR DESCRIPTION
This fixes a display list corruption that happens in Jabu Jabu when using a deku nut.