### PR TITLE
Fix Graveyard scene

### DIFF
--- a/src/code/z_actor.cpp
+++ b/src/code/z_actor.cpp
@@ -1,4 +1,5 @@
 #define INTERNAL_SRC_CODE_Z_ACTOR_C
+#include <algorithm>
 #include "global.h"
 #include "vt.h"
 #include "z64global.h"
@@ -2056,7 +2057,17 @@ void Actor_UpdateAll(GlobalContext* globalCtx, ActorContext* actorCtx) {
     unkFlag = 0;
 
     if (globalCtx->numSetupActors != 0) {
+#ifdef N64_VERSION
         actorEntry = &globalCtx->setupActorList[0];
+#else
+        u8 maxActors = ACTOR_NUMBER_MAX;
+        if (globalCtx->numSetupActors == 57)//Graveyard adult scene
+            maxActors = 48;
+
+        const u8 firstActorToLoad = std::max(globalCtx->numSetupActors, maxActors) - maxActors;
+        actorEntry = &globalCtx->setupActorList[firstActorToLoad];
+        globalCtx->numSetupActors =  std::min(globalCtx->numSetupActors, maxActors);
+#endif
         for (i = 0; i < globalCtx->numSetupActors; i++) {
             Actor_SpawnEntry(&globalCtx->actorCtx, actorEntry++, globalCtx);
         }

--- a/src/code/z_message_PAL.cpp
+++ b/src/code/z_message_PAL.cpp
@@ -176,8 +176,8 @@ void Message_ResetOcarinaNoteState(void) {
         sOcarinaNotesAlphaValues[3] = sOcarinaNotesAlphaValues[4] = sOcarinaNotesAlphaValues[5] =
             sOcarinaNotesAlphaValues[6] = sOcarinaNotesAlphaValues[7] = sOcarinaNotesAlphaValues[8] = 0;
     sOcarinaNoteAPrimR = 80;
-    sOcarinaNoteAPrimG = 255;
-    sOcarinaNoteAPrimB = 150;
+    sOcarinaNoteAPrimG = 150;
+    sOcarinaNoteAPrimB = 255;
     sOcarinaNoteAEnvR = 10;
     sOcarinaNoteAEnvG = 10;
     sOcarinaNoteAEnvB = 10;

--- a/src/overlays/actors/ovl_En_Firefly/z_en_firefly.cpp
+++ b/src/overlays/actors/ovl_En_Firefly/z_en_firefly.cpp
@@ -172,7 +172,6 @@ void EnFirefly_Init(Actor* thisx, GlobalContext* globalCtx) {
 
     if ((pthis->actor.params & 0x8000) != 0) {
         pthis->actor.flags |= ACTOR_FLAG_7;
-        if (1) {}
         pthis->actor.draw = EnFirefly_DrawInvisible;
         pthis->actor.params &= 0x7FFF;
     }


### PR DESCRIPTION
The graveyard scene (adult, day and night) has a lot of actors which are not supposed to be loaded.
In the emulator only the last 48 actors are loaded/active.

I changed things so that only the last 48 actors of every scene are loaded.
This works for every scene except the fight with Ganondorf.
(There are only 3 scenes with more than 48 actors: graveyard day, graveyard night, Ganondorf fight).

I added a check so that the new "load only the last 48 actors routine" is only applied to the graveyard scene.