### PR TITLE
Run Github Actions on dev branch

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -2,9 +2,9 @@ name: Build
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, dev ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, dev ]
 
 env:
   # Configuration type to build.


### PR DESCRIPTION
Changed the github actions workflow file so that the build action also runs for all commits and PRs on the `dev` branch.