### PR TITLE
Put skip cutscene function behind OOT_DEBUG_ROM

### DIFF
--- a/src/code/z_demo.cpp
+++ b/src/code/z_demo.cpp
@@ -1602,10 +1602,12 @@ void Cutscene_ProcessCommands(GlobalContext* globalCtx, CutsceneContext* csCtx, 
         return;
     }
 
+#ifdef OOT_DEBUG_ROM
     if (CHECK_BTN_ALL(globalCtx->state.input[0].press.button, BTN_DRIGHT)) {
         csCtx->state = CS_STATE_UNSKIPPABLE_INIT;
         return;
     }
+#endif
 
     for (i = 0; i < totalEntries; i++) {
         MemCopy(&cmdType, cutscenePtr, sizeof(CutsceneData));


### PR DESCRIPTION
This PR hides the the debug functionally to skip a cutscene behind the compiler flag OOT_DEBUG_ROM.
This fixes issue #228.